### PR TITLE
get data from all fronius converters instead of only the first one

### DIFF
--- a/drivers/fronius/device.js
+++ b/drivers/fronius/device.js
@@ -3,7 +3,7 @@
 const Inverter = require('../../inverter');
 const fetch = require('node-fetch');
 
-const pathName = '/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&DeviceID=1&DataCollection=CommonInverterData';
+const pathName = '/solar_api/v1/GetInverterRealtimeData.cgi?Scope=System&DataCollection=CumulationInverterData';
 
 class Fronius extends Inverter {
     getCronString() {
@@ -39,14 +39,24 @@ class Fronius extends Inverter {
                     this.setStoreValue('lastUpdate', lastUpdate).catch(error => {
                         this.error('Failed setting last update value');
                     });
-
-                    const currentEnergy = Number(response.Body.Data.DAY_ENERGY.Value / 1000);
+					
+					let x = 0;
+					let currentEnergy = 0;
+					
+					for (x in response.Body.Data.DAY_ENERGY.Values) {
+						currentEnergy += Number(response.Body.Data.DAY_ENERGY.Values[x] / 1000);
+					}
+					
                     this.setCapabilityValue('meter_power', currentEnergy);
 
-                    let currentPower;
+                    x = 0;
+					let currentPower = 0;
+					
                     if (response.Body.Data.PAC) {
-                        currentPower = Number(response.Body.Data.PAC.Value);
-                    } else {
+						for (x in response.Body.Data.PAC.Values) {
+						currentPower += Number(response.Body.Data.PAC.Values[x]);
+						}
+					} else {
                         currentPower = null;
                     }
                     this.setCapabilityValue('measure_power', currentPower);    

--- a/drivers/fronius/driver.js
+++ b/drivers/fronius/driver.js
@@ -3,7 +3,7 @@
 const Homey = require('homey');
 const fetch = require('node-fetch');
 
-const pathName = '/solar_api/v1/GetInverterRealtimeData.cgi?Scope=Device&DeviceID=1&DataCollection=CommonInverterData';
+const pathName = '/solar_api/v1/GetInverterRealtimeData.cgi?Scope=System&DataCollection=CumulationInverterData';
 
 class Fronius extends Homey.Driver {
     onPair(socket) {


### PR DESCRIPTION
Hi, 

first at all thanks for your work!
I added the possibilty to get the data from all fronius converters instead of only one. 
For this you need to use a different url in the V1 fronius api and sum up the data values of all converters.

At the end, if you have more than one converter, it will show you all of them in Homey...

Another possibilty would be to add the FroniusDevice-ID (fixed to "1" in your version" to the device and give the homey-Device a custom device-ID so that you can add more thank one fronius devices. That way, users would be able to collect the data of the converters seperatly from each other, that might be better, but I don't know how to add the homey device-ID to your app. 
If you could support with that, then I am able to adjust the device.js to that, too. 

Thanks for your Feedback (and again for you work)!

Sebastian 